### PR TITLE
Dynamic Pines URL

### DIFF
--- a/cedars/app/db.py
+++ b/cedars/app/db.py
@@ -18,6 +18,7 @@ from bson import ObjectId
 from loguru import logger
 
 from .database import mongo, minio
+from .network_conn import get_pines_url
 
 fake = Faker()
 
@@ -1182,7 +1183,14 @@ def get_prediction(note: str) -> float:
 
     Get prediction from endpoint. Text goes in the POST request.
     """
-    url = f'{os.getenv("PINES_API_URL")}/predict'
+
+    host = "ec2-15-206-209-23.ap-south-1.compute.amazonaws.com"
+    port=12345
+
+    #pines_api_url = os.getenv("PINES_API_URL")
+    pines_api_url = get_pines_url(host, port)
+    print(f"\n\nRecived url : {pines_api_url} for pines from {host}", flush=True)
+    url = f'{pines_api_url}/predict'
     data = {'text': note}
     log_notes = None
     try:

--- a/cedars/app/db.py
+++ b/cedars/app/db.py
@@ -1188,8 +1188,9 @@ def get_prediction(note: str) -> float:
     port=12345
 
     #pines_api_url = os.getenv("PINES_API_URL")
+    logger.info(f"Waiting for pines url from {host}:{port}.")
     pines_api_url = get_pines_url(host, port)
-    print(f"\n\nRecived url : {pines_api_url} for pines from {host}", flush=True)
+    logger.info(f"\n\nRecived url : {pines_api_url} for pines from {host}")
     url = f'{pines_api_url}/predict'
     data = {'text': note}
     log_notes = None

--- a/cedars/app/network_conn.py
+++ b/cedars/app/network_conn.py
@@ -1,0 +1,7 @@
+import requests
+from tenacity import retry, wait_fixed
+
+@retry(wait=wait_fixed(2))
+def get_pines_url(host, port):
+    r = requests.post(f"http://{host}:{port}", data={'data': 'pines_url_request'})
+    return r.text

--- a/cedars/pyproject-setup.toml
+++ b/cedars/pyproject-setup.toml
@@ -23,7 +23,8 @@ dependencies = [
     "sqlalchemy",
     "negspacy",
     "flask-session",
-    "faker"
+    "faker",
+    "tenacity"
 ]
 
 [build-system]

--- a/cedars/pyproject.toml
+++ b/cedars/pyproject.toml
@@ -33,6 +33,7 @@ idna = "^3.7"
 flask = "^3.0.3"
 pymongo = "=4.2"
 rq = "^1.16.2"
+tenacity = "9.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pylint = "^2.17.4"


### PR DESCRIPTION
Added functionality to take the PINES api url dynamically from an https server.