### PR TITLE
Removed Redundant Whitespace Around Comments in the UI

### DIFF
--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -423,7 +423,6 @@ def upload_query():
             return redirect(url_for("ops.upload_query"))
 
     if use_pines:
-        # 
         is_pines_available = init_pines_connection(superbio_api_token)
         if is_pines_available is False:
             # PINES could not load successfully

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -663,7 +663,7 @@ def save_adjudications():
         session.modified = True
 
     def _add_annotation_comment():
-        db.add_comment(current_annotation_id, request.form['comment'])
+        db.add_comment(current_annotation_id, request.form['comment'].strip())
 
 
     actions = {

--- a/cedars/app/templates/ops/adjudicate_records.html
+++ b/cedars/app/templates/ops/adjudicate_records.html
@@ -79,7 +79,7 @@
           <h2>Comments</h2>
           <div class="form-group">
             <label for="comment" class="form-label">New Comment</label>
-            <textarea class="form-control" rows="4" name="comment" id="comment">  {{note_comment}} </textarea>
+            <textarea class="form-control" rows="4" name="comment" id="comment" style="padding : 5px">{{note_comment}}</textarea>
           </div>
           <br>
 


### PR DESCRIPTION
- Padding reduced for comments in the UI, no longer gives the impression of extra space characters.
- Comments are all striped of trailing whitespace when entered into the database.

This pull request is set up to fix issue #121 in CEDARS.