### PR TITLE
Sentence Highlight Fix

### DIFF
--- a/cedars/app/nlpprocessor.py
+++ b/cedars/app/nlpprocessor.py
@@ -200,16 +200,12 @@ class NlpProcessor:
                     _, start, end = match
                     token = sentence_annotation[start:end]
                     has_negation = is_negated(token)
-                    start_index = sentence_text.find(token.text, start)
-                    end_index = start_index + len(token.text)
                     token_start = token.start_char
                     token_end = token_start + len(token.text)
                     annotation = {
                                     "sentence": sentence_text,
                                     "token": token.text,
                                     "isNegated": has_negation,
-                                    "start_index": start_index,
-                                    "end_index": end_index,
                                     "note_start_index": token_start,
                                     "note_end_index": token_end,
                                     "sentence_number": sent_no,

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -878,32 +878,17 @@ def get_highlighted_sentence(current_annotation, note):
     highlighted_note = []
     text = note["text"]
 
-
     sentence_start = text.lower().index(current_annotation['sentence'])
-    sentence_end = len(current_annotation['sentence'])
+    sentence_end = sentence_start + len(current_annotation['sentence'])
 
-    # Take characters from the start of the sentence, excluding spaces and new lines.
-    text = text[sentence_start:].strip()
-    prev_end_index = 0
+    token_start_index = current_annotation['note_start_index']
+    token_end_index = current_annotation['note_end_index']
 
-    annotations = db.get_all_annotations_for_sentence(note["text_id"],
-                                                      current_annotation["sentence_number"])
-    logger.info(annotations)
-
-    for annotation in annotations:
-        start_index = annotation['start_index']
-        end_index = annotation['end_index']
-        # Make sure the annotations don't overlap
-        if start_index < prev_end_index:
-            continue
-
-        highlighted_note.append(text[prev_end_index:start_index])
-        highlighted_note.append(f'<b><mark>{text[start_index:end_index]}</mark></b>')
-        prev_end_index = end_index
-
-    highlighted_note.append(text[prev_end_index:sentence_end])
-    logger.info(highlighted_note)
-    return " ".join(highlighted_note).strip().replace("\n", "<br>")
+    sentence = text[sentence_start:token_start_index]
+    sentence += f'<b><mark>{text[token_start_index:token_end_index]}</mark></b>'
+    sentence += text[token_end_index:sentence_end]
+    logger.info(f'Showing sentence : {sentence}')
+    return sentence.strip().replace("\n", "<br>")
 
 def format_annotations(annotations, hide_duplicates):
     """

--- a/cedars/tests/test_db.py
+++ b/cedars/tests/test_db.py
@@ -84,8 +84,6 @@ def test_get_annotation(db, note_id):
     annot_id = annot["_id"]
     res = db.get_annotation(annot_id)
     assert res["token"] == "embolism"
-    assert res["start_index"] == 252
-    assert res["end_index"] == 260
     assert res['note_start_index'] == 252
 
 


### PR DESCRIPTION
The highlighting issues for keywords in sentences was resolved by using exclusively spacy indices instead of calculating them using python. The issue was caused as python was detecting the PE in the word performed instead of the PE instance in the note. The workflow has been switched to spacy indices and the python indices have been deleted from the code to ensure that they will not be used as their data can be incorrect. I have also updated the automated testing to reflect this change.