### PR TITLE
Date Entry Bug Fix

### DIFF
--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -616,8 +616,22 @@ def save_adjudications():
             else:
                 session["index"] = session["unreviewed_annotations_index"].index(1)
         elif 1 in session["unreviewed_annotations_index"]:
-            # any unreviewed annotations left?
-            session["index"] = session["unreviewed_annotations_index"].index(1)
+            # Handles the case of entering a date on a note already marked as
+            # adjudicated
+            if db.get_event_date(session["patient_id"]) is not None:
+                if skip_after_event:
+                    session["unreviewed_annotations_index"] = [0] * len(session["unreviewed_annotations_index"])
+
+                db.mark_note_reviewed(db.get_annotation(current_annotation_id)["note_id"],
+                                      reviewed_by=current_user.username)
+                db.mark_patient_reviewed(session["patient_id"],
+                                         reviewed_by=current_user.username)
+                if skip_after_event:
+                    db.set_patient_lock_status(session["patient_id"], False)
+                    session.pop("patient_id")
+            else:
+                # any unreviewed annotations left?
+                session["index"] = session["unreviewed_annotations_index"].index(1)
         else:
             if session["index"] < session["total_count"] - 1:
                 session["index"] += 1

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -795,7 +795,7 @@ def adjudicate_records():
         db.set_patient_lock_status(patient_id, False)
         return redirect(url_for("ops.adjudicate_records"))
     elif stored_event_date and stored_annotation_id:
-        flash(f"Patient {patient_id} has been reviewed. Showing annotation where event date was marked.")
+        flash(f"Patient {patient_id} has been reviewed. Showing annotation where event date was marked. ")
         logger.info(f"Total annotations for patient {patient_id}: {total_count}")
         session["patient_id"] = patient_id
         session["total_count"] = total_count

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -589,10 +589,15 @@ def save_adjudications():
     def _adjudicate_annotation(updated_date = False):
         logger.debug(f"Adjudicating annotation # {current_annotation_id}")
         skip_after_event = db.get_search_query(query_key="skip_after_event")
+
+        current_patient_id = session["patient_id"]
+        if updated_date and skip_after_event:
+            session["unreviewed_annotations_index"] = [0] * len(session["unreviewed_annotations_index"])
+            db.set_patient_lock_status(current_patient_id, False)
+            session.pop("patient_id")
+
         if session["unreviewed_annotations_index"][session["index"]] == 1:
             db.mark_annotation_reviewed(current_annotation_id)
-            if updated_date and skip_after_event:
-                session["unreviewed_annotations_index"] = [0] * len(session["unreviewed_annotations_index"])
 
             session["unreviewed_annotations_index"][session["index"]] = 0
             session.modified = True
@@ -600,47 +605,41 @@ def save_adjudications():
             # as reviewed because we don't need to review the rest
             # this could be based on a parameter though
             # TODO: add logic based on tags if we need to keep reviewing
-            if len(db.get_patient_annotation_ids(session["patient_id"])) == 0:
-                db.mark_patient_reviewed(session["patient_id"],
+            if len(db.get_patient_annotation_ids(current_patient_id)) == 0:
+                db.mark_patient_reviewed(current_patient_id,
                                          reviewed_by=current_user.username)
-                db.set_patient_lock_status(session["patient_id"], False)
-                session.pop("patient_id")
-            elif db.get_event_date(session["patient_id"]) is not None:
+                db.set_patient_lock_status(current_patient_id, False)
+                if "patient_id" in session:
+                    session.pop("patient_id")
+            elif db.get_event_date(current_patient_id) is not None:
                 db.mark_note_reviewed(db.get_annotation(current_annotation_id)["note_id"],
                                       reviewed_by=current_user.username)
-                db.mark_patient_reviewed(session["patient_id"],
+                db.mark_patient_reviewed(current_patient_id,
                                          reviewed_by=current_user.username)
                 if db.get_search_query(query_key="skip_after_event"):
-                    db.set_patient_lock_status(session["patient_id"], False)
-                    session.pop("patient_id")
+                    db.set_patient_lock_status(current_patient_id, False)
+                    if "patient_id" in session:
+                        session.pop("patient_id")
             else:
                 session["index"] = session["unreviewed_annotations_index"].index(1)
         elif 1 in session["unreviewed_annotations_index"]:
-            # Handles the case of entering a date on a note already marked as
-            # adjudicated
-            if updated_date and skip_after_event:
-                session["unreviewed_annotations_index"] = [0] * len(session["unreviewed_annotations_index"])
-                db.set_patient_lock_status(session["patient_id"], False)
-                session.pop("patient_id")
-
-            if db.get_event_date(session["patient_id"]) is not None:
+            if db.get_event_date(current_patient_id) is not None:
                 db.mark_note_reviewed(db.get_annotation(current_annotation_id)["note_id"],
                                       reviewed_by=current_user.username)
-                db.mark_patient_reviewed(session["patient_id"],
+                db.mark_patient_reviewed(current_patient_id,
                                          reviewed_by=current_user.username)
-                    
             else:
                 # any unreviewed annotations left?
                 session["index"] = session["unreviewed_annotations_index"].index(1)
         else:
-            if session["index"] < session["total_count"] - 1:
-                session["index"] += 1
-            else:
+            is_last_note = (session["index"] >= session["total_count"] - 1)
+            if is_last_note or (updated_date and skip_after_event):
                 # If the index and reached the end of a patient's notes
                 # and there are no unreviewed annotations left
                 # Then this patient has been fully reviewed and can be popped.
-                db.set_patient_lock_status(session["patient_id"], False)
-                session.pop("patient_id")
+                db.set_patient_lock_status(current_patient_id, False)
+            else:
+                session["index"] += 1
 
         session.modified = True
 
@@ -787,12 +786,22 @@ def adjudicate_records():
     total_count = res["total"]
     all_annotation_index = res["all_annotation_index"]
     unreviewed_annotations_index = res["unreviewed_annotations_index"]
+    stored_event_date = db.get_event_date(patient_id)
+    stored_annotation_id = db.get_event_annotation_id(patient_id)
 
     if total_count == 0:
         logger.info(f"Patient {patient_id} has no annotations. Showing next patient")
         flash(f"Patient {patient_id} has no annotations. Showing next patient")
         db.set_patient_lock_status(patient_id, False)
         return redirect(url_for("ops.adjudicate_records"))
+    elif stored_event_date and stored_annotation_id:
+        logger.info(f"Total annotations for patient {patient_id}: {total_count}")
+        session["patient_id"] = patient_id
+        session["total_count"] = total_count
+        session["annotations"] = annotations
+        session["all_annotation_index"] = all_annotation_index
+        session["unreviewed_annotations_index"] = unreviewed_annotations_index
+        session["index"] = all_annotation_index[annotations.index(stored_annotation_id)]
     elif unreviewed_annotations_index.count(1) == 0:
         flash(f"Patient {patient_id} has no annotations left review. Showing all annotations.")
         session["patient_id"] = patient_id

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -592,7 +592,6 @@ def save_adjudications():
 
         current_patient_id = session["patient_id"]
         if updated_date and skip_after_event:
-            session["unreviewed_annotations_index"] = [0] * len(session["unreviewed_annotations_index"])
             db.set_patient_lock_status(current_patient_id, False)
             session.pop("patient_id")
 

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -618,17 +618,17 @@ def save_adjudications():
         elif 1 in session["unreviewed_annotations_index"]:
             # Handles the case of entering a date on a note already marked as
             # adjudicated
-            if db.get_event_date(session["patient_id"]) is not None:
-                if skip_after_event:
-                    session["unreviewed_annotations_index"] = [0] * len(session["unreviewed_annotations_index"])
+            if updated_date and skip_after_event:
+                session["unreviewed_annotations_index"] = [0] * len(session["unreviewed_annotations_index"])
+                db.set_patient_lock_status(session["patient_id"], False)
+                session.pop("patient_id")
 
+            if db.get_event_date(session["patient_id"]) is not None:
                 db.mark_note_reviewed(db.get_annotation(current_annotation_id)["note_id"],
                                       reviewed_by=current_user.username)
                 db.mark_patient_reviewed(session["patient_id"],
                                          reviewed_by=current_user.username)
-                if skip_after_event:
-                    db.set_patient_lock_status(session["patient_id"], False)
-                    session.pop("patient_id")
+                    
             else:
                 # any unreviewed annotations left?
                 session["index"] = session["unreviewed_annotations_index"].index(1)

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -795,6 +795,7 @@ def adjudicate_records():
         db.set_patient_lock_status(patient_id, False)
         return redirect(url_for("ops.adjudicate_records"))
     elif stored_event_date and stored_annotation_id:
+        flash(f"Patient {patient_id} has been reviewed. Showing annotation where event date was marked.")
         logger.info(f"Total annotations for patient {patient_id}: {total_count}")
         session["patient_id"] = patient_id
         session["total_count"] = total_count

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -3,7 +3,7 @@ This page contatins the functions and the flask blueprint for the /proj_details 
 """
 import os
 import re
-from datetime import datetime, timezone
+from datetime import datetime
 import tempfile
 import pandas as pd
 import pyarrow.parquet as pq


### PR DESCRIPTION
Fixed bug when entering event date for sentence already marked as annotated. This checks that if a note has been annotated but a new date is entered, it will automatically mark everything as reviewed for that patient.