### PR TITLE
Continuous Patient Updates

### DIFF
--- a/cedars/app/db.py
+++ b/cedars/app/db.py
@@ -397,7 +397,7 @@ def insert_one_annotation(annotation):
 
     annotations_collection.insert_one(annotation)
 
-def upsert_patient_results(patient_id: str):
+def upsert_patient_results(patient_id: str, insert_datetime: datetime = None):
     '''
     Stores the results of a patient who has been reviewed.
     If this patient already has results stored, the code will
@@ -467,7 +467,8 @@ def upsert_patient_results(patient_id: str):
         'max_score_note_id' : max_score_note_id,
         'max_score_note_date' : max_score_note_date,
         'max_score' : max_score,
-        'predicted_notes' : all_note_details
+        'predicted_notes' : all_note_details,
+        'Last Updated' : insert_datetime,
     }
 
     if patient_results_exist(patient_id):
@@ -1259,7 +1260,7 @@ def mark_patient_reviewed(patient_id: str, reviewed_by: str, is_reviewed=True):
                                               "reviewed_by": reviewed_by}})
 
     logger.info(f"Storing results for patient #{patient_id}")
-    upsert_patient_results(patient_id)
+    upsert_patient_results(patient_id, datetime.now())
 
 
 def mark_note_reviewed(note_id, reviewed_by: str):
@@ -1306,7 +1307,6 @@ def add_comment(annotation_id, comment):
                                     {"$set":
                                      {"comments": comment}
                                      })
-    upsert_patient_results(patient_id)
 
 
 def set_patient_lock_status(patient_id: str, status):

--- a/cedars/app/db.py
+++ b/cedars/app/db.py
@@ -397,7 +397,7 @@ def insert_one_annotation(annotation):
 
     annotations_collection.insert_one(annotation)
 
-def upsert_patient_results(patient_id: str, insert_datetime: datetime = None):
+def upsert_patient_results(patient_id: str, insert_datetime: datetime = None, updated_by: str = None):
     '''
     Stores the results of a patient who has been reviewed.
     If this patient already has results stored, the code will
@@ -436,7 +436,11 @@ def upsert_patient_results(patient_id: str, insert_datetime: datetime = None):
     last_note_date = get_last_note_date_for_patient(patient_id)
     patient = get_patient_by_id(patient_id)
     comments = patient.get("comments", "")
-    reviewer = get_patient_reviewer(patient_id)
+
+    if updated_by is not None:
+        reviewer = updated_by
+    else:
+        reviewer = get_patient_reviewer(patient_id)
 
     max_score = None
     max_score_note_id = ""
@@ -468,7 +472,7 @@ def upsert_patient_results(patient_id: str, insert_datetime: datetime = None):
         'max_score_note_date' : max_score_note_date,
         'max_score' : max_score,
         'predicted_notes' : all_note_details,
-        'Last Updated' : insert_datetime,
+        'last_updated' : insert_datetime,
     }
 
     if patient_results_exist(patient_id):
@@ -1740,7 +1744,8 @@ def download_annotations(filename: str = "annotations.csv", get_sentences: bool 
         'max_score_note_id': pl.Utf8,
         'max_score_note_date': pl.Datetime,
         'max_score': pl.Float64,
-        'predicted_notes': pl.Utf8
+        'predicted_notes': pl.Utf8,
+        'last_updated' : pl.Datetime
     }
 
     if  get_sentences is False:

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -553,13 +553,11 @@ def save_adjudications():
         new_date = request.form['date_entry']
         logger.info(f"Updating event date for {patient_id}: {new_date}")
         db.update_event_date(patient_id, new_date, current_annotation_id)
-        db.upsert_patient_results(patient_id)
         _adjudicate_annotation(updated_date = True)
 
     def _delete_event_date():
         logger.info(f"Deleting event date for {patient_id}")
         db.delete_event_date(patient_id)
-        db.upsert_patient_results(patient_id)
 
     def _move_to_previous_annotation(shift_value):
         def shift_index_backwards():
@@ -652,6 +650,7 @@ def save_adjudications():
     if action in actions:
         actions[action]()
     _add_annotation_comment()
+    db.upsert_patient_results(patient_id, datetime.now())
 
     # the session has been cleared so get the next patient
     if session.get("patient_id") is None:

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -650,7 +650,8 @@ def save_adjudications():
     if action in actions:
         actions[action]()
     _add_annotation_comment()
-    db.upsert_patient_results(patient_id, datetime.now())
+    db.upsert_patient_results(patient_id, datetime.now(),
+                              updated_by = current_user.username)
 
     # the session has been cleared so get the next patient
     if session.get("patient_id") is None:

--- a/docs/download_annotations.md
+++ b/docs/download_annotations.md
@@ -22,6 +22,7 @@ The table for the regular download will have the following columns:
     13. max_score_note_id (The note date for which PINES found the highest probability of an event. Will be empty if no PINES model was used.)
     14. max_score (The highest score PINES assigned to any note for this patient. Will be empty if no PINES model was used.)
     15. predicted_notes (The note IDs with the predicted scores for this patient. Will be empty if no PINES model was used.)
+    16. last_updated (A datetime stamp of the last time this patient's RESULTS were updated.)
 
 If a full download task is created an additional column will be added to the output file :
 


### PR DESCRIPTION
Changes made : 
- Patient RESULTS are now updated in real time while any annotator is reviewing that patient.
- RESULTS now include a timestamp of when the last change is made.
- The reviewer for a patient will be the last entity to make ANY changes to the patient.
- Download schema updated in the documentation