### PR TITLE
Putting patient updates into the queue

### DIFF
--- a/cedars/tests/test_adj.py
+++ b/cedars/tests/test_adj.py
@@ -93,6 +93,8 @@ def test_filter_duplicates_by_note(annotations, expected_indices):
                 'annotation_ids': ["1", "3"],
                 'review_statuses': [ReviewStatus.REVIEWED, ReviewStatus.UNREVIEWED],
                 'current_index': 1,  # First unreviewed annotation
+                'annotations': [{'_id': '1', 'note_id': 'N1', 'sentence': 'Test sentence 1', 'reviewed': 1},
+                                {'_id': '3', 'note_id': 'N2', 'sentence': 'Test sentence 2', 'reviewed': 0}],
             },
             ["2"],
         ),
@@ -111,6 +113,8 @@ def test_filter_duplicates_by_note(annotations, expected_indices):
                 'annotation_ids': ["1", "2"],
                 'review_statuses': [ReviewStatus.REVIEWED, ReviewStatus.REVIEWED],
                 'current_index': 1,  # Stored annotation ID index
+                'annotations': [{'_id': '1', 'note_id': 'N1', 'sentence': 'Test sentence 1', 'reviewed': 1},
+                                {'_id': '2', 'note_id': 'N2', 'sentence': 'Test sentence 2', 'reviewed': 1}],
             },
             [],
         ),
@@ -129,6 +133,8 @@ def test_filter_duplicates_by_note(annotations, expected_indices):
                 'annotation_ids': ["1", "2"],
                 'review_statuses': [ReviewStatus.REVIEWED, ReviewStatus.REVIEWED],
                 'current_index': 0,  # Default to index 0
+                'annotations': [{'_id': '1', 'note_id': 'N1', 'sentence': 'Test sentence 1', 'reviewed': 1},
+                                {'_id': '2', 'note_id': 'N2', 'sentence': 'Test sentence 2', 'reviewed': 1}],
             },
             [],
         ),


### PR DESCRIPTION
Database updates to patient comments, reviewed annotations and the RESULTS collection are all queued. When an event date is entered or deleted a similar queuing process happens for that patient. Note that if a task for a patient is enqueued when entering or deleting a date, the second job is not required and is then skipped.