### PR TITLE
Clear cache on terminate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,11 @@ jobs:
       #     # If you use a different name, update COMMENT_FILENAME accordingly
       #     path: python-coverage-comment-action.txt
       
-      # - name: Build documentation
-      #   run: mkdocs build
+      - name: Build documentation
+        run: mkdocs build
             
-      # - name: Deploy to GitHub Pages
-      #   uses: peaceiris/actions-gh-pages@v3
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_dir: ./docs
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/cedars/app/ops.py
+++ b/cedars/app/ops.py
@@ -110,6 +110,7 @@ def project_details():
                     db.terminate_project()
                     # reset all rq queues
                     flask.current_app.task_queue.empty()
+                    flask.current_app.ops_queue.empty()
                     auth.logout_user()
                     session.clear()
                     flash("Project Terminated.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,13 @@ site_name: CEDARS
 nav:
   - Overview: README.md # This needs to be linked back with ..\, DO transfer this file to the repo
   - About: ABOUT.md
+  - Basic Concepts: basic_concepts.md
+  - Quickstart: getting_started.md
   - Administrator Manual: CEDARS_admin_manual.md
   - Annotator Manual: CEDARS_annotator_manual.md
+  - Input File Format: upload_file_format.md
+  - Search Query Manual: query_database.md
+  - Download Results: download_annotations.md
   - Terms of Use: TERMS_OF_USE.md # This needs to be linked back with ..\, do NOT transfer this file to repo
 
 theme: 


### PR DESCRIPTION
The cache for the ops queue will be emptied when the project is terminated. Docs will also update automatically to reflect changes from now on.